### PR TITLE
Update add_markers.sh

### DIFF
--- a/catkin_ws/src/scripts/add_markers.sh
+++ b/catkin_ws/src/scripts/add_markers.sh
@@ -19,10 +19,8 @@ xterm  -e  " cd $(pwd)/../..;
 source devel/setup.bash; 
 roslaunch turtlebot_rviz_launchers view_navigation.launch " &
 
-sleep 15
+sleep 20
 
 xterm  -e  " cd $(pwd)/../..;
-
 source devel/setup.bash; 
-
 rosrun add_markers add_markers_2 "


### PR DESCRIPTION
feat: sleep time should be longer

due to the late response of the rviz navigation, the sleep time between the rviz launch and the add_markers node should be longer